### PR TITLE
Change heading of "minimal information"

### DIFF
--- a/draft-iab-path-signals-collaboration.md
+++ b/draft-iab-path-signals-collaboration.md
@@ -341,7 +341,7 @@ information sharing:
   As a result, typically an application's consent is not the same as
   the user's consent.
 
-## Minimum Information
+## Minimize Information
 
 Each party should provide only the information that is needed for the
 other parties to perform the task for which collaboration is desired,


### PR DESCRIPTION
I propose this change of the section heading as the section actually doesn't say to take the absolute minimum but says you should provide the right information. So I think this heading reflects the section content slightly better.